### PR TITLE
concatenate all pangenome fasta and rename headers appropriately

### DIFF
--- a/smelter/main.py
+++ b/smelter/main.py
@@ -16,18 +16,69 @@ import sys
 assert sys.version_info >= (3, 6), "Please run this script with Python version >= 3.6."
 
 
-import os
+from os.path import dirname, basename, abspath, isdir
 import traceback
-from utilities import tsprint, backtick, makedirs
+import json
+import random
+import time
+from utilities import tsprint, backtick, makedirs, tsv_rows, parse_table, ProgressTracker
 
 
 def smelt(argv):
-    tsprint(f"cd {backtick('pwd')}")
-    tsprint(' '.join(argv))
+    cwd = backtick('pwd')
+    tsprint(
+        f"cd {cwd}\n" +
+        ' '.join(argv)
+    )
     _, subcmd, outdir, iggtoc = argv
     assert subcmd.replace("-", "_").lower() == "build_gsnap_index"
-    assert os.path.basename(iggtoc) == "species_info.tsv"
+    assert basename(iggtoc) == "species_info.tsv"
+    try:
+        metadata = dirname(abspath(iggtoc))
+        assert basename(metadata) == "metadata"
+        iggdb = dirname(metadata)
+        # assert re.match("^v[0-9]+\.[0-9]+\.[0-9]+$", basename(iggdb))
+        pangenomes = f"{iggdb}/pangenomes"
+        assert isdir(pangenomes)
+    except Exception as e:
+        e.help_text = f"Unexpected directory structure for MIDAS-IGGdb database around {iggtoc}."
+        raise
     makedirs(outdir, exist_ok=False)
+    species = list(parse_table(tsv_rows(iggtoc)))
+    tsprint(f"Found {len(species)} species in {iggtoc}, for example:")
+    random.seed(time.time())
+    random_index = random.randrange(0, len(species))
+    tsprint(json.dumps(species[random_index], indent=4))
+    tsprint("Now collating fasta for gsnap index construction.")
+    MAX_FAILURES = 100
+    count_successes = 0
+    ticker = ProgressTracker(target=len(species))
+    failures = []
+    for s in species:
+        # Prepend species_alt_id to each header in the species pangenome, and append to all.fa.
+        try:
+            s_species_alt_id = s['species_alt_id']
+            s_pangenome = f"{pangenomes}/{s_species_alt_id}/centroids.fa"
+            s_tempfile = f"{outdir}/temp_{s_species_alt_id}.fa"
+            s_header_xform = f"sed 's=^>=>{s_species_alt_id}|=' {s_pangenome} > {s_tempfile} && cat {s_tempfile} >> {outdir}/pangenomes.fa && rm {s_tempfile} && echo SUCCEEDED || echo FAILED"
+            status = backtick(s_header_xform)
+            assert status == "SUCCEEDED"
+            count_successes += 1
+        except Exception as e:
+            failures.append(s)
+            if len(failures) == MAX_FAILURES:
+                count_examined = len(failures) + count_successes
+                e.help_text = f"Giving up after {MAX_FAILURES} failures in first {count_examined} species.  See temp files for more info."
+                raise
+        finally:
+            ticker.advance(1)
+    if failures:
+        failed_species_alt_ids = [s['species_alt_id'] for s in failures]
+        tsprint(f"Ignoring {len(failures)} failed species: {json.dumps(failed_species_alt_ids, indent=4)}")
+        tsprint("For more informaiton on each failed species, see its corresponding temp file.")
+        tsprint(f"Only {count_successes} of {len(species)} species were processed successfully.")
+    else:
+        tsprint(f"All {len(species)} species were processed successfully.")
 
 
 def main():


### PR DESCRIPTION
example run

```
1548758567.4 cd /home/ubuntu/ebs/midas-iggdb/smelter
1548758567.4 /home/ubuntu/ebs/MIDAS-IGGdb/smelter/main.py build_gsnap_index candidate_index ../../IGGdb/v1.0.0/metadata/species_info.tsv
1548758567.5 Found 23790 species in ../../IGGdb/v1.0.0/metadata/species_info.tsv, for example:
1548758567.5 {
1548758567.5     "species_id": "OTU-13940",
1548758567.5     "species_alt_id": "276129",
1548758567.5     "species_name": "Halanaerobium hydrogeniformans",
...
1548758567.5     "high_quality": "Yes"
1548758567.5 }
1548758567.5 Now collating fasta for gsnap index construction.
1548758567.5 *** 0.0 percent done, 0.0 minutes elapsed, 11.7 minutes remaining, ETA 10:54:30
1548758597.5 *** 5.6 percent done, 0.5 minutes elapsed, 16.7 minutes remaining, ETA 11:00:00
1548758627.6 *** 10.7 percent done, 1.0 minutes elapsed, 16.8 minutes remaining, ETA 11:00:35
1548758657.6 *** 15.7 percent done, 1.5 minutes elapsed, 16.1 minutes remaining, ETA 11:00:22
1548758687.6 *** 20.9 percent done, 2.0 minutes elapsed, 15.2 minutes remaining, ETA 10:59:56
...
1548759107.8 *** 94.3 percent done, 9.0 minutes elapsed, 1.1 minutes remaining, ETA 10:52:53 ***
1548759137.8 *** 99.7 percent done, 9.5 minutes elapsed, 0.0 minutes remaining, ETA 10:52:20 ***
1548759139.3 All 23790 species were processed successfully.
```