### PR TITLE
flag to permit sparse output from snp counting

### DIFF
--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -188,6 +188,8 @@ def species_pileup(species_id):
 	header = ['ref_id', 'ref_pos', 'ref_allele', 'depth', 'count_a', 'count_c', 'count_g', 'count_t']
 	out_file.write('\t'.join(header)+'\n')
 
+	zero_rows_allowed = not args['sparse']
+
 	# compute coverage
 	bampath = '%s/snps/temp/genomes.bam' % args['outdir']
 	with pysam.AlignmentFile(bampath, 'rb') as bamfile:
@@ -214,7 +216,8 @@ def species_pileup(species_id):
 				count_g = counts[2][i]
 				count_t = counts[3][i]
 				row = [contig_id, ref_pos, ref_allele, depth, count_a, count_c, count_g, count_t]
-				out_file.write('\t'.join([str(_) for _ in row])+'\n')
+				if depth > 0 or zero_rows_allowed:
+					out_file.write('\t'.join([str(_) for _ in row])+'\n')
 				aln_stats['genome_length'] += 1
 				aln_stats['total_depth'] += depth
 				if depth > 0: aln_stats['covered_bases'] += 1

--- a/scripts/run_midas.py
+++ b/scripts/run_midas.py
@@ -432,6 +432,8 @@ Can be gzip'ed (extension: .gz) or bzip2'ed (extension: .bz2)""")
 		help='Enable BAQ: per-base alignment quality (False)')
 	snps.add_argument('--adjust_mq', default=False, action='store_true',
 		help='Adjust MAPQ (False)')
+	snps.add_argument('--sparse', default=False, action='store_true',
+		help='Omit zero rows from output.')
 	args = vars(parser.parse_args())
 	if args['species_id']: args['species_id'] = args['species_id'].split(',')
 	return args


### PR DESCRIPTION
For a sample with 6 mil reads (unpaired), against DB of 974 species, this proceeds at 29,000 reads per second.   Overall run time 3.5 minutes (down from 9 minutes without the --sparse flag).