### PR TITLE
chunyu/pangenome testing for UHGG

### DIFF
--- a/midas/run/genes.py
+++ b/midas/run/genes.py
@@ -35,9 +35,7 @@ class Species:
 def initialize_species(args):
     species = {}
     splist = '%s/snps/species.txt' % args['outdir']
-    #args['build_db'] = False
-    ## cz: to avoid generate the SRR10029237/results/snps/species.txt
-    if False: #args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
+    if args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
         from midas.run.species import select_species
         with open(splist, 'w') as outfile:
             for id in select_species(args):

--- a/midas/run/genes.py
+++ b/midas/run/genes.py
@@ -35,8 +35,9 @@ class Species:
 def initialize_species(args):
     species = {}
     splist = '%s/snps/species.txt' % args['outdir']
-    args['build_db'] = False
-    if args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
+    #args['build_db'] = False
+    ## cz: to avoid generate the SRR10029237/results/snps/species.txt
+    if False: #args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
         from midas.run.species import select_species
         with open(splist, 'w') as outfile:
             for id in select_species(args):
@@ -118,9 +119,8 @@ def build_pangenome_db(args, species):
     command += '%s/genes/temp/pangenomes ' % args['outdir']
     args['log'].write('command: '+command+'\n')
     print(command)
-    #process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     utility.check_exit_code(process, command)
-    exit(0)
 
 def pangenome_align(args):
     """ Use Bowtie2 to map reads to all specified genome species """
@@ -155,7 +155,6 @@ def pangenome_align(args):
     print("  checking bamfile integrity")
     print("bampath:=> ", bampath)
     utility.check_bamfile(args, bampath)
-    exit(0)
 
 def pangenome_coverage(args, species, genes):
     """ Compute coverage of pangenome for species_id and write results to disk """
@@ -279,7 +278,7 @@ def run_pipeline(args):
     print("  %s Gb maximum memory" % utility.max_mem_usage())
 
     # Build pangenome database for selected species
-    if args['build_db']:
+    if True: #args['build_db']:
         print("\nBuilding pangenome database")
         args['log'].write("\nBuilding pangenome database\n")
         start = time()

--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -28,6 +28,7 @@ class Species:
 		self.mean_coverage = 0
 
 	def fetch_paths(self, iggdb):
+		print("fetch_path:", self.id)
 		self.paths['fna'] = iggdb.get_species(species_id=self.id)['repgenome_path']
 
 class Contig:
@@ -251,7 +252,7 @@ def pysam_pileup(args, species, contigs):
 
 	global global_contigs
 	global_contigs = contigs
-	
+
 	tsprint("Read contigs")
 
 	mp = multiprocessing.Pool(int(args['threads']))

--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -38,7 +38,6 @@ class Contig:
 def initialize_species(args):
 	species = {}
 	splist = '%s/snps/species.txt' % args['outdir']
-	args['build_db'] = False
 	if args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
 		from midas.run.species import select_species
 		with open(splist, 'w') as outfile:

--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -28,7 +28,6 @@ class Species:
 		self.mean_coverage = 0
 
 	def fetch_paths(self, iggdb):
-		print("fetch_path:", self.id)
 		self.paths['fna'] = iggdb.get_species(species_id=self.id)['repgenome_path']
 
 class Contig:
@@ -37,10 +36,9 @@ class Contig:
 		self.id = id
 
 def initialize_species(args):
-	#print("snps.py, args", args )
 	species = {}
 	splist = '%s/snps/species.txt' % args['outdir']
-	print("snps.py: splist", splist)
+	args['build_db'] = False
 	if args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
 		from midas.run.species import select_species
 		with open(splist, 'w') as outfile:
@@ -52,6 +50,7 @@ def initialize_species(args):
 			id = line.rstrip()
 			species[id] = Species(id)
 	iggdb = args['iggdb']
+	print("initialize_species: iggdb", iggdb)
 	for sp in species.values():
 		sp.fetch_paths(iggdb)
 	return species

--- a/midas/run/snps.py
+++ b/midas/run/snps.py
@@ -37,8 +37,10 @@ class Contig:
 		self.id = id
 
 def initialize_species(args):
+	#print("snps.py, args", args )
 	species = {}
 	splist = '%s/snps/species.txt' % args['outdir']
+	print("snps.py: splist", splist)
 	if args['build_db'] or (args['all_species_in_db'] and not os.path.isfile(splist)):
 		from midas.run.species import select_species
 		with open(splist, 'w') as outfile:

--- a/midas/utility.py
+++ b/midas/utility.py
@@ -114,10 +114,16 @@ def add_executables(args):
 	src_dir = os.path.dirname(os.path.abspath(__file__))
 	main_dir = os.path.dirname(src_dir)
 	args['stream_seqs'] = '/'.join([src_dir, 'run', 'stream_seqs.py'])
-	args['hs-blastn'] = '/'.join([main_dir, 'bin', platform.system(), 'hs-blastn'])
-	args['bowtie2-build'] = '/'.join([main_dir, 'bin', platform.system(), 'bowtie2-build'])
-	args['bowtie2'] = '/'.join([main_dir, 'bin', platform.system(), 'bowtie2'])
-	args['samtools'] = '/'.join([main_dir, 'bin', platform.system(), 'samtools'])
+	#args['hs-blastn'] = '/'.join([main_dir, 'bin', platform.system(), 'hs-blastn'])
+	#args['bowtie2-build'] = '/'.join([main_dir, 'bin', platform.system(), 'bowtie2-build'])
+	#args['bowtie2'] = '/'.join([main_dir, 'bin', platform.system(), 'bowtie2'])
+	#args['samtools'] = '/'.join([main_dir, 'bin', platform.system(), 'samtools'])
+	CONDA_PREFIX = os.getenv("CONDA_PREFIX")
+	args['hs-blastn'] = '/'.join([CONDA_PREFIX, 'bin', 'hs-blastn'])
+	args['bowtie2-build'] = '/'.join([CONDA_PREFIX, 'bin', 'bowtie2-build'])
+	args['bowtie2'] = '/'.join([CONDA_PREFIX, 'bin', 'bowtie2'])
+	args['samtools'] = '/'.join([CONDA_PREFIX, 'bin', 'samtools'])
+
 
 	for arg in ['hs-blastn', 'stream_seqs', 'bowtie2-build', 'bowtie2', 'samtools']:
 		if not os.path.isfile(args[arg]):

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,8 @@ MIDAS=`dirname ${REALME}`
 EBSROOT=`dirname ${MIDAS}`
 export PYTHONPATH=$PYTHONPATH:${MIDAS}:${MIDAS}/smelter
 export PATH=$PATH:${MIDAS}/scripts
-export MIDAS_DB=${EBSROOT}/IGGdb/v1.0.0
+#export MIDAS_DB=${EBSROOT}/IGGdb/v1.0.0
+export MIDAS_DB=${EBSROOT}/IGGdb/v2.0.0_2019_July
 
 if [ ! -d ${MIDAS_DB} ]; then
    echo "Directory ${MIDAS_DB} not found.  Please provide it, or adjust ${REALME} for your install."

--- a/scripts/run_midas.py
+++ b/scripts/run_midas.py
@@ -254,7 +254,7 @@ By default, the MIDAS_DB environmental variable is used""")
 	db.add_argument('--species_cov', type=float, dest='species_cov', metavar='FLOAT', help='Include species with >X coverage (3.0)')
 	db.add_argument('--species_topn', type=int, dest='species_topn', metavar='INT', help='Include top N most abundant species')
 	db.add_argument('--species_id', type=str, dest='species_id', metavar='CHAR', help='Include specified species. Separate ids with a comma')
-	db.add_argument('--species_id_file', type=str, dest='species_id_file', metavar='CHAR', help='Include species from specified file, one species per line.')	
+	db.add_argument('--species_id_file', type=str, dest='species_id_file', metavar='CHAR', help='Include species from specified file, one species per line.')
 	db.add_argument('--all_species_in_db', default=False, action='store_true', dest='all_species_in_db', help='Include every species in DB, regardless of species abundance in sample.')
 	align = parser.add_argument_group('Read alignment options (if using --align)')
 	align.add_argument('-1', type=str, dest='m1', required=True,

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -32,7 +32,6 @@ class IGGdb:
             random.seed(time.time())
             random_index = random.randrange(0, len(self.species_info))
             tsprint(json.dumps(self.species_info[random_index], indent=4))
-        print("IGGdb: iggdb_toc_species", iggdb_toc_species)
         self.species = {s['species_id']: s for s in self.species_info}
         print("IGGdb: self species", self.species)
         self.genomes = {g['genome_id']: g for g in self.genome_info}

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -39,7 +39,7 @@ class IGGdb:
             genome_id = s['representative_genome']
             g = self.genomes[genome_id]
             #s['repgenome_with_origin'] = genome_id + "." + g['repository'].lower()
-            s['repgenome_path'] = f"{self.iggdb_root}/repgenomes/{genome_id}/{genome_id}.fna.lz4"
+            s['repgenome_path'] = f"{self.iggdb_root}/repgenomes/{genome_id}/{genome_id}.fna"
             s['pangenome_path'] = f"{self.iggdb_root}/pangenomes/{s['species_alt_id']}"
 
 

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -32,7 +32,9 @@ class IGGdb:
             random.seed(time.time())
             random_index = random.randrange(0, len(self.species_info))
             tsprint(json.dumps(self.species_info[random_index], indent=4))
+        print("IGGdb: iggdb_toc_species", iggdb_toc_species)
         self.species = {s['species_id']: s for s in self.species_info}
+        print("IGGdb: self species", self.species)
         self.genomes = {g['genome_id']: g for g in self.genome_info}
         for s in self.species_info:
             genome_id = s['representative_genome']

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -33,7 +33,6 @@ class IGGdb:
             random_index = random.randrange(0, len(self.species_info))
             tsprint(json.dumps(self.species_info[random_index], indent=4))
         self.species = {s['species_id']: s for s in self.species_info}
-        print("IGGdb: self species", self.species)
         self.genomes = {g['genome_id']: g for g in self.genome_info}
         for s in self.species_info:
             genome_id = s['representative_genome']

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -37,8 +37,8 @@ class IGGdb:
         for s in self.species_info:
             genome_id = s['representative_genome']
             g = self.genomes[genome_id]
-            s['repgenome_with_origin'] = genome_id + "." + g['repository'].lower()
-            s['repgenome_path'] = f"{self.iggdb_root}/repgenomes/{s['repgenome_with_origin']}.fna"
+            #s['repgenome_with_origin'] = genome_id + "." + g['repository'].lower()
+            s['repgenome_path'] = f"{self.iggdb_root}/repgenomes/{genome_id}/{genome_id}.fna.lz4"
             s['pangenome_path'] = f"{self.iggdb_root}/pangenomes/{s['species_alt_id']}"
 
 

--- a/smelter/iggdb.py
+++ b/smelter/iggdb.py
@@ -38,7 +38,7 @@ class IGGdb:
         for s in self.species_info:
             genome_id = s['representative_genome']
             g = self.genomes[genome_id]
-            #s['repgenome_with_origin'] = genome_id + "." + g['repository'].lower()
+            ##s['repgenome_with_origin'] = genome_id + "." + g['repository'].lower()
             s['repgenome_path'] = f"{self.iggdb_root}/repgenomes/{genome_id}/{genome_id}.fna"
             s['pangenome_path'] = f"{self.iggdb_root}/pangenomes/{s['species_alt_id']}"
 


### PR DESCRIPTION
I tested the gene workflow using the newly generated marker_genes and the pangenomes (gene clusters) for the UHGG dataset (GUT_GENOME000001 for testing purpose).

The command to run;
```
data_dir=/path/to/sample
./run.sh genes $data_dir//SRR10029237/results \
  -1 $data_dir/SRR10029237_1.fastq.gz -2 $data-dir/SRR10029237_2.fastq.gz \
  -t 8 --all_species_in_db
```

notes: Since the IGGsearch species_profile.txt is generate using IGGdb, by `all_species_in_db` we can walk around the inconsistency between IGGdb and UHGGdb genome_id, and testing the functionality of the genes workflow.

I also turned off the hard-coded bowie2 path in midas/utility.py and used the CONDA path instead. 
